### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <h2.version>2.2.224</h2.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <java.version>11</java.version>
         <jdbi.version>2.78</jdbi.version>
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <liquibase.version>4.25.1</liquibase.version>
         <maven-build-info-plugin.version>1.3</maven-build-info-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-git-commit-id-plugin.version>4.9.10</maven-git-commit-id-plugin.version>
         <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
     <version>2.1.2-SNAPSHOT</version>
     <properties>
-        <byte-buddy.version>1.14.14</byte-buddy.version>
+        <byte-buddy.version>1.14.18</byte-buddy.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <flyway.version>9.8.3</flyway.version>
         <guava.version>33.2.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <guava.version>32.0.0-jre</guava.version>
         <h2.version>2.2.224</h2.version>
         <hsqldb.version>2.7.1</hsqldb.version>
-        <jackson-bom.version>2.17.0</jackson-bom.version>
+        <jackson-bom.version>2.17.2</jackson-bom.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <java.version>11</java.version>
         <jdbi.version>2.78</jdbi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
         <mockito.version>5.12.0</mockito.version>
-        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <rxjava-jdbc.version>0.7.19</rxjava-jdbc.version>
         <slf4j.version>2.0.12</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <liquibase.version>4.25.1</liquibase.version>
         <maven-build-info-plugin.version>1.3</maven-build-info-plugin.version>
-        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-git-commit-id-plugin.version>4.9.10</maven-git-commit-id-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-git-commit-id-plugin.version>4.9.10</maven-git-commit-id-plugin.version>
         <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <mockito.version>5.12.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
         <mockito.version>5.12.0</mockito.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <byte-buddy.version>1.14.14</byte-buddy.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <flyway.version>9.8.3</flyway.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>33.2.1-jre</guava.version>
         <h2.version>2.2.224</h2.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <mockito.version>5.11.0</mockito.version>
+        <mockito.version>5.12.0</mockito.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <rxjava-jdbc.version>0.7.19</rxjava-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven-build-info-plugin.version>1.3</maven-build-info-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
-        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-git-commit-id-plugin.version>4.9.10</maven-git-commit-id-plugin.version>
         <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>


### PR DESCRIPTION
- **Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.5.0 to 3.7.0**
- **Bump org.apache.maven.plugins:maven-compiler-plugin**
- **Bump org.jacoco:jacoco-maven-plugin from 0.8.11 to 0.8.12**
- **Bump com.google.guava:guava from 32.0.0-jre to 33.2.1-jre**
- **Bump org.apache.maven.plugins:maven-enforcer-plugin from 3.4.1 to 3.5.0**
- **Bump mockito.version from 5.11.0 to 5.12.0**
- **Bump org.sonatype.plugins:nexus-staging-maven-plugin**
- **Bump org.apache.maven.plugins:maven-dependency-plugin**
- **Bump com.fasterxml.jackson:jackson-bom from 2.17.0 to 2.17.2**
- **Bump net.bytebuddy:byte-buddy from 1.14.14 to 1.14.18**
- **Bump org.apache.maven.plugins:maven-surefire-plugin from 2.22.2 to 3.3.1**
